### PR TITLE
feat: enable ja/en routing and locale-aware SEO metadata (#17)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,13 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
 	reactStrictMode: true,
+	// NOTE: src/lib/i18n.ts の LOCALES / DEFAULT_LOCALE と必ず同期させること
+	i18n: {
+		locales: ['ja', 'en'],
+		defaultLocale: 'en',
+		// Accept-Language による自動リダイレクトはしない(切り替えは UI から明示操作のみ)
+		localeDetection: false,
+	},
 	images: {
 		remotePatterns: [
 			{

--- a/src/components/meta.tsx
+++ b/src/components/meta.tsx
@@ -1,9 +1,7 @@
 import Head from 'next/head'
 import { useRouter } from 'next/router'
-
-// サイトに関する情報
-import { siteMeta } from '../lib/constants'
-const { siteTitle, siteDesc, siteUrl, siteLocale, siteType, siteIcon } = siteMeta
+import { DEFAULT_LOCALE, LOCALES, localizePath, resolveLocale } from 'src/lib/i18n'
+import { siteMetaByLocale } from '../lib/constants'
 
 // 汎用OGP画像
 import siteImg from '../images/ogp.png'
@@ -17,15 +15,18 @@ interface MetaProps {
 }
 
 export default function Meta({ pageTitle, pageDesc, pageImg, pageImgW, pageImgH }: MetaProps) {
+	const router = useRouter()
+	const locale = resolveLocale(router.locale)
+	const { siteTitle, siteDesc, siteUrl, siteLocale, siteType, siteIcon } = siteMetaByLocale[locale]
+
 	// ページのタイトル
 	const title = pageTitle ? `${pageTitle} | ${siteTitle}` : siteTitle
 
 	// ページの説明
 	const desc = pageDesc ?? siteDesc
 
-	// ページのURL
-	const router = useRouter()
-	const url = `${siteUrl}${router.asPath}`
+	// ページのURL(router.asPath にはロケールプレフィックスが含まれないため付与する)
+	const url = `${siteUrl}${localizePath(router.asPath, locale)}`
 
 	// OGP画像
 	const img = pageImg || siteImg.src
@@ -40,6 +41,19 @@ export default function Meta({ pageTitle, pageDesc, pageImg, pageImgW, pageImgH 
 			<meta name="description" content={desc} />
 			<meta property="og:description" content={desc} />
 			<link rel="canonical" href={url} />
+			{LOCALES.map((altLocale) => (
+				<link
+					key={altLocale}
+					rel="alternate"
+					hrefLang={altLocale}
+					href={`${siteUrl}${localizePath(router.asPath, altLocale)}`}
+				/>
+			))}
+			<link
+				rel="alternate"
+				hrefLang="x-default"
+				href={`${siteUrl}${localizePath(router.asPath, DEFAULT_LOCALE)}`}
+			/>
 			<meta property="og:url" content={url} />
 			<meta property="og:site_name" content={siteTitle} />
 			<meta property="og:type" content={siteType} /> {/* コンテンツの種類 */}

--- a/src/lib/constants.test.ts
+++ b/src/lib/constants.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { siteMetaByLocale } from './constants'
+
+describe('siteMetaByLocale', () => {
+	it('ja は現行の siteMeta と同じ値を持つ', () => {
+		expect(siteMetaByLocale.ja.siteLang).toBe('ja')
+		expect(siteMetaByLocale.ja.siteLocale).toBe('ja_JP')
+		expect(siteMetaByLocale.ja.siteDesc).toBe('アウトプットしていくサイト')
+	})
+
+	it('en は英語ロケール情報を持つ', () => {
+		expect(siteMetaByLocale.en.siteLang).toBe('en')
+		expect(siteMetaByLocale.en.siteLocale).toBe('en_US')
+	})
+
+	it('ロケール非依存の値は ja/en で一致する', () => {
+		expect(siteMetaByLocale.en.siteTitle).toBe(siteMetaByLocale.ja.siteTitle)
+		expect(siteMetaByLocale.en.siteUrl).toBe(siteMetaByLocale.ja.siteUrl)
+		expect(siteMetaByLocale.en.siteIcon).toBe(siteMetaByLocale.ja.siteIcon)
+	})
+})

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,13 +1,25 @@
 import type { SiteMeta, Eyecatch } from 'src/types'
+import type { Locale } from './i18n'
 
-export const siteMeta: SiteMeta = {
-	siteTitle: 'Intro',
-	siteDesc: 'アウトプットしていくサイト',
-	siteUrl: 'https://*********',
-	siteLang: 'ja',
-	siteLocale: 'ja_JP',
-	siteType: 'website',
-	siteIcon: '/favicon.png',
+export const siteMetaByLocale: Record<Locale, SiteMeta> = {
+	ja: {
+		siteTitle: 'Intro',
+		siteDesc: 'アウトプットしていくサイト',
+		siteUrl: 'https://*********',
+		siteLang: 'ja',
+		siteLocale: 'ja_JP',
+		siteType: 'website',
+		siteIcon: '/favicon.png',
+	},
+	en: {
+		siteTitle: 'Intro',
+		siteDesc: 'A portfolio site where I share my output',
+		siteUrl: 'https://*********',
+		siteLang: 'en',
+		siteLocale: 'en_US',
+		siteType: 'website',
+		siteIcon: '/favicon.png',
+	},
 }
 
 export const eyecatchLocal: Eyecatch = {

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,11 +1,8 @@
 import { Html, Head, Main, NextScript } from 'next/document'
-import { siteMeta } from '../lib/constants'
-
-const { siteLang } = siteMeta
 
 export default function Document() {
 	return (
-		<Html lang={siteLang}>
+		<Html>
 			<Head />
 			<body>
 				<Main />

--- a/src/pages/contents/[slug].tsx
+++ b/src/pages/contents/[slug].tsx
@@ -87,11 +87,14 @@ export default function Post({
 	)
 }
 
-export const getStaticPaths: GetStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async ({ locales }) => {
 	const allSlugs = await getAllSlugs()
 	return {
-		// getStaticPropsの引数contextとして使用
-		paths: allSlugs.map(({ slug }) => `/contents/${slug}`),
+		// i18n 有効時、文字列 paths はデフォルトロケール分しか生成されないため
+		// 全ロケール × 全スラッグをオブジェクト形式で列挙する
+		paths: allSlugs.flatMap(({ slug }) =>
+			(locales ?? []).map((locale) => ({ params: { slug }, locale })),
+		),
 		fallback: false,
 	}
 }

--- a/src/pages/contents/category/[slug].tsx
+++ b/src/pages/contents/category/[slug].tsx
@@ -23,10 +23,12 @@ export default function Category({ name, posts }: CategoryPageProps) {
 	)
 }
 
-export const getStaticPaths: GetStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths = async ({ locales }) => {
 	const allCats = await getAllCategories()
 	return {
-		paths: allCats.map(({ slug }) => `/contents/category/${slug}`),
+		paths: allCats.flatMap(({ slug }) =>
+			(locales ?? []).map((locale) => ({ params: { slug }, locale })),
+		),
 		fallback: false,
 	}
 }


### PR DESCRIPTION
Closes #17

## 変更内容(3秒で読める要約)

Next.jsのi18nルーティング(ja/en、デフォルト英語)を有効化し、canonical/hreflangとサイトメタをロケール別に出し分け。

## 確認方法

- [ ] `npm test` が通る
- [ ] `npx tsc --noEmit` がクリーン
- [ ] `npx next build` で `/en/...` `/ja/...` 両方の静的パスが生成される