### PR TITLE
feat: add dictionary-driven site copy and a language switcher (#18)

### DIFF
--- a/src/components/lang-switcher.tsx
+++ b/src/components/lang-switcher.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import { LOCALES, resolveLocale, type Locale } from 'src/lib/i18n'
+import styles from 'src/styles/lang-switcher.module.css'
+
+const LABELS: Record<Locale, string> = {
+	ja: 'JA',
+	en: 'EN',
+}
+
+export default function LangSwitcher() {
+	const router = useRouter()
+	const current = resolveLocale(router.locale)
+
+	return (
+		<ul className={styles.list}>
+			{LOCALES.map((locale) => (
+				<li key={locale}>
+					{locale === current ? (
+						<span className={styles.current} aria-current="true">
+							{LABELS[locale]}
+						</span>
+					) : (
+						// href は asPath のまま、locale プロパティでプレフィックスを切り替える
+						<Link href={router.asPath} locale={locale} hrefLang={locale}>
+							{LABELS[locale]}
+						</Link>
+					)}
+				</li>
+			))}
+		</ul>
+	)
+}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,6 +1,7 @@
 import Container from './container'
 import Logo from '../logo'
 import Nav from '../nav'
+import LangSwitcher from '../lang-switcher'
 import styles from 'src/styles/header.module.css'
 
 export default function Header() {
@@ -9,7 +10,10 @@ export default function Header() {
 			<Container large>
 				<div className={styles.flexContainer}>
 					<Logo boxOn />
-					<Nav />
+					<div className={styles.navGroup}>
+						<LangSwitcher />
+						<Nav />
+					</div>
 				</div>
 			</Container>
 		</header>

--- a/src/lib/dictionary.test.ts
+++ b/src/lib/dictionary.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { dictionaries } from './dictionary'
+
+function keyPaths(value: unknown, prefix = ''): string[] {
+	if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+		return [prefix]
+	}
+	return Object.entries(value).flatMap(([key, child]) =>
+		keyPaths(child, prefix ? `${prefix}.${key}` : key),
+	)
+}
+
+describe('dictionaries', () => {
+	it('ja と en は同一のキー構造を持つ(訳し漏れ防止)', () => {
+		expect(keyPaths(dictionaries.en).sort()).toEqual(keyPaths(dictionaries.ja).sort())
+	})
+
+	it('ja は現行の表示文字列を維持する', () => {
+		expect(dictionaries.ja.about.pageTitle).toBe('アバウト')
+		expect(dictionaries.ja.posts.pageTitle).toBe('ブログ')
+		expect(dictionaries.ja.posts.pageDesc).toBe('ブログの記事一覧')
+	})
+
+	it('en は英語文字列を持つ', () => {
+		expect(dictionaries.en.about.pageTitle).toBe('About')
+		expect(dictionaries.en.posts.pageTitle).toBe('Blog')
+	})
+
+	it('category.pageDesc はカテゴリ名を埋め込む', () => {
+		expect(dictionaries.ja.category.pageDesc('技術')).toBe('技術に関する記事')
+		expect(dictionaries.en.category.pageDesc('Tech')).toBe('Posts about Tech')
+	})
+
+	it('about.body は段落構造を持つ', () => {
+		for (const dict of [dictionaries.ja, dictionaries.en]) {
+			expect(dict.about.body.length).toBeGreaterThan(0)
+			for (const block of dict.about.body) {
+				expect(['p', 'h2', 'h3']).toContain(block.tag)
+				expect(block.text.length).toBeGreaterThan(0)
+			}
+		}
+	})
+})

--- a/src/lib/dictionary.ts
+++ b/src/lib/dictionary.ts
@@ -1,0 +1,78 @@
+import type { Locale } from './i18n'
+
+interface AboutBodyBlock {
+	tag: 'p' | 'h2' | 'h3'
+	text: string
+}
+
+export interface Dictionary {
+	about: {
+		pageTitle: string
+		pageDesc: string
+		body: ReadonlyArray<AboutBodyBlock>
+	}
+	posts: {
+		pageTitle: string
+		pageDesc: string
+	}
+	category: {
+		pageDesc: (name: string) => string
+	}
+}
+
+// ja の値は現行表示と完全一致させること(ja の見た目を変えない)
+// about.body は現状プレースホルダー(lorem ipsum)。実文面は後で差し替える
+const loremShort =
+	'Lorem ipsum dolor sit amet consectetur adipisicing elit. Culpa eveniet architecto alias quaerat, quod error, iste fugit totam aliquid cum magni explicabo eius delectus earum dolor assumenda nemo similique odit?'
+
+const ja: Dictionary = {
+	about: {
+		pageTitle: 'アバウト',
+		pageDesc: "Who's Portfolio site?",
+		body: [
+			{
+				tag: 'p',
+				text: 'Lorem ipsum dolor sit amet consectetur adipisicing elit. Rem voluptatibus commodi inventore a esse asperiores voluptate quasi ratione saepe minus eligendi ab veritatis suscipit repellat assumenda cumque nam, quidem pariatur!',
+			},
+			{ tag: 'h2', text: 'pug pug pug' },
+			{ tag: 'p', text: loremShort },
+			{ tag: 'p', text: loremShort },
+			{ tag: 'h3', text: 'pug pug pug' },
+			{ tag: 'p', text: loremShort },
+		],
+	},
+	posts: {
+		pageTitle: 'ブログ',
+		pageDesc: 'ブログの記事一覧',
+	},
+	category: {
+		pageDesc: (name: string) => `${name}に関する記事`,
+	},
+}
+
+const en: Dictionary = {
+	about: {
+		pageTitle: 'About',
+		pageDesc: "Who's Portfolio site?",
+		body: [
+			{
+				tag: 'p',
+				text: 'Placeholder introduction in English. Replace with the real self-introduction copy.',
+			},
+			{ tag: 'h2', text: 'pug pug pug' },
+			{ tag: 'p', text: 'Placeholder paragraph in English.' },
+			{ tag: 'p', text: 'Placeholder paragraph in English.' },
+			{ tag: 'h3', text: 'pug pug pug' },
+			{ tag: 'p', text: 'Placeholder paragraph in English.' },
+		],
+	},
+	posts: {
+		pageTitle: 'Blog',
+		pageDesc: 'All blog posts',
+	},
+	category: {
+		pageDesc: (name: string) => `Posts about ${name}`,
+	},
+}
+
+export const dictionaries: Record<Locale, Dictionary> = { ja, en }

--- a/src/lib/use-dictionary.ts
+++ b/src/lib/use-dictionary.ts
@@ -1,0 +1,8 @@
+import { useRouter } from 'next/router'
+import { dictionaries, type Dictionary } from './dictionary'
+import { resolveLocale } from './i18n'
+
+export function useDictionary(): Dictionary {
+	const { locale } = useRouter()
+	return dictionaries[resolveLocale(locale)]
+}

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -6,13 +6,15 @@ import TwoColumn, { TwoColumnMain, TwoColumnSidebar } from '../components/layout
 import Image from 'next/image'
 import eyecatch from '../images/about_pug_1920*960.png'
 import Meta from '../components/meta'
+import { useDictionary } from 'src/lib/use-dictionary'
 
 export default function About() {
+	const { about } = useDictionary()
 	return (
 		<Container>
 			<Meta
-				pageTitle="アバウト"
-				pageDesc="Who's Portfolio site?"
+				pageTitle={about.pageTitle}
+				pageDesc={about.pageDesc}
 				pageImg={eyecatch.src}
 				// eyecatchから高さと横幅を取り出して指定
 				pageImgW={eyecatch.width}
@@ -36,28 +38,15 @@ export default function About() {
 					{' '}
 					{/* 本文 */}
 					<PostBody>
-						<p>
-							Lorem ipsum dolor sit amet consectetur adipisicing elit. Rem voluptatibus commodi
-							inventore a esse asperiores voluptate quasi ratione saepe minus eligendi ab veritatis
-							suscipit repellat assumenda cumque nam, quidem pariatur!
-						</p>
-						<h2>pug pug pug</h2>
-						<p>
-							Lorem ipsum dolor sit amet consectetur adipisicing elit. Culpa eveniet architecto
-							alias quaerat, quod error, iste fugit totam aliquid cum magni explicabo eius delectus
-							earum dolor assumenda nemo similique odit?
-						</p>
-						<p>
-							Lorem ipsum dolor sit amet consectetur adipisicing elit. Culpa eveniet architecto
-							alias quaerat, quod error, iste fugit totam aliquid cum magni explicabo eius delectus
-							earum dolor assumenda nemo similique odit?
-						</p>
-						<h3>pug pug pug</h3>
-						<p>
-							Lorem ipsum dolor sit amet consectetur adipisicing elit. Culpa eveniet architecto
-							alias quaerat, quod error, iste fugit totam aliquid cum magni explicabo eius delectus
-							earum dolor assumenda nemo similique odit?
-						</p>
+						{about.body.map((block, index) => {
+							if (block.tag === 'h2') {
+								return <h2 key={index}>{block.text}</h2>
+							}
+							if (block.tag === 'h3') {
+								return <h3 key={index}>{block.text}</h3>
+							}
+							return <p key={index}>{block.text}</p>
+						})}
 					</PostBody>
 				</TwoColumnMain>
 				<TwoColumnSidebar>

--- a/src/pages/contents/category/[slug].tsx
+++ b/src/pages/contents/category/[slug].tsx
@@ -7,6 +7,7 @@ import Posts from 'src/components/post/posts'
 import { eyecatchLocal } from 'src/lib/constants' // ローカルの代替アイキャッチ画像
 import type { PostListItem } from 'src/types'
 import type { GetStaticPaths, GetStaticProps } from 'next'
+import { useDictionary } from 'src/lib/use-dictionary'
 
 interface CategoryPageProps {
 	name: string
@@ -14,9 +15,10 @@ interface CategoryPageProps {
 }
 
 export default function Category({ name, posts }: CategoryPageProps) {
+	const { category } = useDictionary()
 	return (
 		<Container>
-			<Meta pageTitle={name} pageDesc={`${name}に関する記事`} />
+			<Meta pageTitle={name} pageDesc={category.pageDesc(name)} />
 			<PostHeader title={name} subtitle="Blog Contents Category" />
 			<Posts posts={posts} />
 		</Container>

--- a/src/pages/contents/index.tsx
+++ b/src/pages/contents/index.tsx
@@ -7,15 +7,17 @@ import Posts from 'src/components/post/posts'
 import { eyecatchLocal } from 'src/lib/constants' // ローカルの代替アイキャッチ画像
 import type { PostListItem } from 'src/types'
 import type { GetStaticProps } from 'next'
+import { useDictionary } from 'src/lib/use-dictionary'
 
 interface ContentsProps {
 	posts: PostListItem[]
 }
 
 export default function Contents({ posts }: ContentsProps) {
+	const { posts: postsDict } = useDictionary()
 	return (
 		<Container>
-			<Meta pageTitle="ブログ" pageDesc="ブログの記事一覧" />
+			<Meta pageTitle={postsDict.pageTitle} pageDesc={postsDict.pageDesc} />
 
 			<Hero title="Posts" subtitle="Recent Posts" />
 

--- a/src/styles/header.module.css
+++ b/src/styles/header.module.css
@@ -2,3 +2,9 @@
 	composes: spaceBetween from './utils.module.css';
 	gap: 1em;
 }
+
+.navGroup {
+	display: flex;
+	align-items: center;
+	gap: 1.5em;
+}

--- a/src/styles/lang-switcher.module.css
+++ b/src/styles/lang-switcher.module.css
@@ -1,0 +1,21 @@
+.list {
+	display: flex;
+	gap: 0.75em;
+	list-style: none;
+	padding: 0;
+	font-size: 0.875rem;
+}
+
+.current {
+	font-weight: 700;
+}
+
+.list a {
+	color: var(--gray-75);
+}
+
+@media (hover: hover) {
+	.list a:hover {
+		color: var(--accent);
+	}
+}


### PR DESCRIPTION
Closes #18

## 変更内容(3秒で読める要約)

サイト文言をja/en辞書から取得する仕組みと、ヘッダーの言語スイッチャーを追加。Aboutページ本文はまだプレースホルダー。

## 確認方法

- [ ] `npm test` が通る
- [ ] `npx tsc --noEmit` がクリーン
- [ ] `npx next build` が成功