### PR TITLE
feat: write the About page bio and add a last-updated stamp (#19)

### DIFF
--- a/src/lib/dictionary.ts
+++ b/src/lib/dictionary.ts
@@ -5,10 +5,14 @@ interface AboutBodyBlock {
 	text: string
 }
 
+// About ページの「最終更新」日(ISO)。内容を直したらこの1行だけ手で更新する。
+export const aboutLastUpdated = '2026-07-08'
+
 export interface Dictionary {
 	about: {
 		pageTitle: string
 		pageDesc: string
+		lastUpdatedLabel: string
 		body: ReadonlyArray<AboutBodyBlock>
 	}
 	posts: {
@@ -20,25 +24,35 @@ export interface Dictionary {
 	}
 }
 
-// ja の値は現行表示と完全一致させること(ja の見た目を変えない)
-// about.body は現状プレースホルダー(lorem ipsum)。実文面は後で差し替える
-const loremShort =
-	'Lorem ipsum dolor sit amet consectetur adipisicing elit. Culpa eveniet architecto alias quaerat, quod error, iste fugit totam aliquid cum magni explicabo eius delectus earum dolor assumenda nemo similique odit?'
-
 const ja: Dictionary = {
 	about: {
 		pageTitle: 'アバウト',
-		pageDesc: "Who's Portfolio site?",
+		pageDesc: 'Soma Tomita について。関西でソフトウェアをつくったり、いろんなものに寄り道したり。',
+		lastUpdatedLabel: '最終更新',
 		body: [
 			{
 				tag: 'p',
-				text: 'Lorem ipsum dolor sit amet consectetur adipisicing elit. Rem voluptatibus commodi inventore a esse asperiores voluptate quasi ratione saepe minus eligendi ab veritatis suscipit repellat assumenda cumque nam, quidem pariatur!',
+				text: 'はじめまして、Soma Tomita です。関西でソフトウェアを書いて暮らしています。趣味はたくさんありますが、最近はもっぱら個人開発に時間を使っています。',
 			},
-			{ tag: 'h2', text: 'pug pug pug' },
-			{ tag: 'p', text: loremShort },
-			{ tag: 'p', text: loremShort },
-			{ tag: 'h3', text: 'pug pug pug' },
-			{ tag: 'p', text: loremShort },
+			{ tag: 'h2', text: '好きなもの、たくさん' },
+			{
+				tag: 'p',
+				text: '興味の幅が広くて、正直まとまりがありません。ジムで筋トレ、機会があればサウナやゴルフ。うまいラーメンと静かな居酒屋をめぐって、週末が許すかぎり温泉に浸かる。MARVEL映画とミュージカル、量が多すぎるアニメ、K-pop や Hiphop、最近はまっているテクノやトランス、サッカー、スニーカー、カラオケ、頂上の景色めあてのハイキング、それに歴史館や美術館めぐり。どれもないときは、本か podcast、呆れるほどの回数のクラロワや最近はじめたポケモンチャンピオンズ、あるいは謝る気のない昼寝です。',
+			},
+			{ tag: 'h2', text: '旅のこと' },
+			{
+				tag: 'p',
+				text: 'これまでに足を運んだのは 🇺🇸🇬🇺🇰🇷🇸🇬🇵🇭🇱🇦🇹🇭🇫🇮🇦🇹🇸🇰🇮🇳🇭🇰🇩🇪🇳🇱🇲🇾🇨🇳 の 16 か国ほど。その多くは旅行ではなく、留学やインターン、語学プログラムなど、腰を据えて「その土地で人がどう暮らしているのか」を見にいったものがほとんどです。純粋に遊びで行ったのは、ドイツ、オランダ、韓国、香港、中国など。どちらにしても、新しい場所へ行きたい気持ちは消えていなくて、次にどこへ行き着くのか、自分でもちょっと楽しみにしています。',
+			},
+			{ tag: 'h2', text: 'ものをつくるようになるまで' },
+			{
+				tag: 'p',
+				text: 'エンジニアには一直線で来たわけではありません。学んだのは経済学で、大学時代は講義室よりも SDGs や教育のプロジェクトに時間を使い、コードを本格的に書く前は国際物流の仕事をしていました。いまは教育分野のプロダクトをフルスタックで開発していて、その途中で英国 University of York の情報科学の修士も終えました。この遠回りこそが自分らしいのだと思います。ソフトウェアでも、まだ見ぬ土地でも、変えにいく前に「なぜそうなっているのか」を知りたくなる性分です。',
+			},
+			{
+				tag: 'p',
+				text: 'このサイトは、つくったものや、いま頭の中でこねているものを置いておく場所です。立ち寄ってくれてありがとうございます。上のどれかがあなたの「好きなもの」と重なっていたら、なおうれしいです。',
+			},
 		],
 	},
 	posts: {
@@ -53,17 +67,33 @@ const ja: Dictionary = {
 const en: Dictionary = {
 	about: {
 		pageTitle: 'About',
-		pageDesc: "Who's Portfolio site?",
+		pageDesc:
+			'About Soma Tomita, a Kansai-based software engineer who is curious about a little too much.',
+		lastUpdatedLabel: 'Last updated',
 		body: [
 			{
 				tag: 'p',
-				text: 'Placeholder introduction in English. Replace with the real self-introduction copy.',
+				text: "Hi, I'm Soma Tomita. I write software for a living in Kansai. I have plenty of hobbies, but lately most of my free time goes into personal projects.",
 			},
-			{ tag: 'h2', text: 'pug pug pug' },
-			{ tag: 'p', text: 'Placeholder paragraph in English.' },
-			{ tag: 'p', text: 'Placeholder paragraph in English.' },
-			{ tag: 'h3', text: 'pug pug pug' },
-			{ tag: 'p', text: 'Placeholder paragraph in English.' },
+			{ tag: 'h2', text: "Things I'm into" },
+			{
+				tag: 'p',
+				text: 'The list is long and a little all over the place. Lifting at the gym, plus sauna and golf when I get the chance. Chasing good ramen and quiet izakaya, and soaking in as many hot springs as a weekend allows. Marvel films and musicals, far too much anime, K-pop and hip-hop with a recent detour into techno and trance, football, sneakers, karaoke, hiking for the view at the top, and wandering through history and art museums. When none of that is happening, a book, a podcast, an absurd number of Clash Royale matches, my newly started Pokémon Champions habit, or a nap I refuse to apologize for.',
+			},
+			{ tag: 'h2', text: 'Travel' },
+			{
+				tag: 'p',
+				text: "So far that's 🇺🇸🇬🇺🇰🇷🇸🇬🇵🇭🇱🇦🇹🇭🇫🇮🇦🇹🇸🇰🇮🇳🇭🇰🇩🇪🇳🇱🇲🇾🇨🇳, sixteen or so countries, though not many of them were holidays. Most were study abroad, internships, and language programs, going somewhere with a reason to stay a while and see how people actually live day to day. The trips that were purely for fun were places like Germany, the Netherlands, Korea, Hong Kong, and China. Either way, the urge to go somewhere new has not gone away, so I stay a little curious about where I might end up next.",
+			},
+			{ tag: 'h2', text: 'How I ended up building things' },
+			{
+				tag: 'p',
+				text: "I did not take a straight line into engineering. I studied economics, spent more of university on SDGs and education projects than in lecture halls, and worked in international logistics before I wrote code seriously. These days I build full-stack products in education technology, and I finished a computer science master's at the University of York in the UK along the way. The winding route is kind of the point. I like to understand why something works before I try to change it, whether that is a piece of software or a place I have never been.",
+			},
+			{
+				tag: 'p',
+				text: "This site is where I keep the things I make and the things I'm still chewing on. Thanks for stopping by, and if any of the above overlaps with your own list, even better.",
+			},
 		],
 	},
 	posts: {

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -7,9 +7,25 @@ import Image from 'next/image'
 import eyecatch from '../images/about_pug_1920*960.png'
 import Meta from '../components/meta'
 import { useDictionary } from 'src/lib/use-dictionary'
+import { aboutLastUpdated } from 'src/lib/dictionary'
+import { resolveLocale } from 'src/lib/i18n'
+import { useRouter } from 'next/router'
+import { parseISO, format } from 'date-fns'
+import { ja, enUS } from 'date-fns/locale'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faClock } from '@fortawesome/free-regular-svg-icons'
+import styles from 'src/styles/about.module.css'
+
+const dateLocale = { ja, en: enUS } as const
+const datePattern = { ja: 'yyyy年MM月dd日', en: 'MMMM d, yyyy' } as const
 
 export default function About() {
 	const { about } = useDictionary()
+	const locale = resolveLocale(useRouter().locale)
+	const updatedLabel = format(parseISO(aboutLastUpdated), datePattern[locale], {
+		locale: dateLocale[locale],
+	})
+
 	return (
 		<Container>
 			<Meta
@@ -48,6 +64,13 @@ export default function About() {
 							return <p key={index}>{block.text}</p>
 						})}
 					</PostBody>
+					{/* 最終更新日(dictionary.ts の aboutLastUpdated を手で更新する) */}
+					<p className={styles.updated}>
+						<FontAwesomeIcon icon={faClock} size="lg" color="var(--gray-25)" />
+						<span>
+							{about.lastUpdatedLabel} <time dateTime={aboutLastUpdated}>{updatedLabel}</time>
+						</span>
+					</p>
 				</TwoColumnMain>
 				<TwoColumnSidebar>
 					{' '}

--- a/src/styles/about.module.css
+++ b/src/styles/about.module.css
@@ -1,0 +1,8 @@
+.updated {
+	display: flex;
+	gap: 0.5em;
+	align-items: center;
+	margin-top: var(--space-sm);
+	color: var(--gray-50);
+	font-size: var(--small-heading3);
+}


### PR DESCRIPTION
Closes #19

## 変更内容(3秒で読める要約)

Aboutページのプレースホルダー本文を実際の自己紹介(ja/en)に差し替え、最終更新日の表示を追加。

## 確認方法

- [ ] `npm test` が通る
- [ ] `npx tsc --noEmit` がクリーン
- [ ] `npx next build` が成功